### PR TITLE
Hook up submit button to API

### DIFF
--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -41,7 +41,7 @@ const Review: React.FC<{}> = () => {
       {/* TODO: programmatically render the form values here */}
 
       <br />
-      <Text>Your claim will not be filed unless you click Submit below.</Text>
+      <Text>{translate(getCopy('submit:instructions'), language)}</Text>
       <br />
 
       <Button

--- a/src/form.json
+++ b/src/form.json
@@ -225,6 +225,11 @@
       "es": "Enviar",
       "zh": "提交"
     },
+    "submit:instructions": {
+      "en": "Your claim will not be filed unless you click Submit below.",
+      "es": "Su reclamo no se archivará a menos que haga clic en Enviar a continuación.",
+      "zh": "除非您单击下面的提交，否则不会提出您的索赔。"
+    },
     "demo-warning": {
       "en": "This is for demo purposes only. Email pua-requests@usdigitalresponse.org to learn more.",
       "es": "Esto es solo para fines de demostración.",


### PR DESCRIPTION
This PR updates the styling of the submit page as filler until we have a design ready for this page:

![image](https://user-images.githubusercontent.com/2907397/79625742-e1a57200-80df-11ea-88f7-ab2165cbfd43.png)

And the submit button now submits the real form data.

There's plenty more to do here around rendering the form submission + forcing all validation to succeed before submitting, but that'll be handled in a future PR.