### PR TITLE
Clean up Introduction HTML to reduce React dev errors

### DIFF
--- a/src/components/Introduction.tsx
+++ b/src/components/Introduction.tsx
@@ -8,61 +8,111 @@ const Introduction: React.FC = () => {
 
   return (
     <>
-      <Box pad="medium">
-        <Heading level={3} color="black" margin={{ top: 'none', bottom: 'none' }}>
+      <Box pad={{ horizontal: 'medium' }}>
+        <Heading level={3} color="black">
           {translate(getCopy('introduction:header'), language)}
         </Heading>
-        <Paragraph fill={true} color="black">
+        <Paragraph fill={true} color="black" margin={{ vertical: 'xsmall' }}>
           {translate(getCopy('introduction:welcome'), language)}
-          <br />
-          <br />
-          {translate(getCopy('introduction:background'), language)}
-          <br />
-          <br />
-          {translate(getCopy('introduction:payment'), language)}
-          <br />
-          <br />
-          <Text weight={600}>{translate(getCopy('preparation:header'), language)}</Text>
-          <br />
-          <Text weight={400}>{translate(getCopy('preparation:instructions'), language)}</Text>
-          <ul color="black">
-            <li color="black">{translate(getCopy('preparation:ssn'), language)}</li>
-            <li color="black">{translate(getCopy('preparation:agi'), language)}</li>
-            <li color="black">{translate(getCopy('preparation:employment'), language)}</li>
-            <li color="black">{translate(getCopy('preparation:arn'), language)}</li>
-            <li color="black">{translate(getCopy('preparation:children'), language)}</li>
-            <li color="black">{translate(getCopy('preparation:license'), language)}</li>
-            <li color="black">{translate(getCopy('preparation:bank'), language)}</li>
-          </ul>
-          <br />
-          <Text weight={600}>{translate(getCopy('eligibility:header'), language)}</Text>
-          <br />
-          <Text weight={400}>{translate(getCopy('eligibility:instructions'), language)}</Text>
-          <ul color="black">
-            <li color="black">{translate(getCopy('eligibility:workers'), language)}</li>
-            <li color="black">{translate(getCopy('eligibility:unemployed'), language)}</li>
-            <li color="black">{translate(getCopy('eligibility:no-fault'), language)}</li>
-          </ul>
-          <br />
-          <Text weight={400}>{translate(getCopy('eligibility:other-state'), language)}</Text>
-          <br />
-          <br />
-          <Text weight={400}>{translate(getCopy('pandemic-eligibility:instructions'), language)}</Text>
-          <ol color="black">
-            <li color="black">{translate(getCopy('pandemic-eligibility:1'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:2'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:3'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:4'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:5'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:6'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:7'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:8'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:9'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:10'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:11'), language)}</li>
-            <li color="black">{translate(getCopy('pandemic-eligibility:12'), language)}</li>
-          </ol>
         </Paragraph>
+        <Paragraph fill={true} color="black" margin={{ vertical: 'xsmall' }}>
+          {translate(getCopy('introduction:background'), language)}
+        </Paragraph>
+        <Paragraph fill={true} color="black" margin={{ vertical: 'xsmall' }}>
+          {translate(getCopy('introduction:payment'), language)}
+        </Paragraph>
+
+        <Heading level={4} color="black" margin={{ bottom: 'xsmall' }}>
+          {translate(getCopy('preparation:header'), language)}
+        </Heading>
+        <Paragraph fill={true} color="black" margin={{ vertical: 'none' }}>
+          {translate(getCopy('preparation:instructions'), language)}
+        </Paragraph>
+        <ul color="black">
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:ssn'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:agi'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:employment'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:arn'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:children'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:license'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('preparation:bank'), language)}</li>
+          </Text>
+        </ul>
+
+        <Heading level={4} color="black" margin={{ bottom: 'xsmall' }}>
+          {translate(getCopy('eligibility:header'), language)}
+        </Heading>
+        <Paragraph fill={true} color="black" margin={{ vertical: 'none' }}>
+          {translate(getCopy('eligibility:instructions'), language)}
+        </Paragraph>
+        <ul color="black">
+          <Text color="black">
+            <li color="black">{translate(getCopy('eligibility:workers'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('eligibility:unemployed'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('eligibility:no-fault'), language)}</li>
+          </Text>
+        </ul>
+        <Paragraph fill={true} color="black" margin={{ vertical: 'none' }}>
+          {translate(getCopy('eligibility:other-state'), language)}
+        </Paragraph>
+        <Paragraph fill={true} color="black" margin={{ top: 'small', bottom: 'none' }}>
+          {translate(getCopy('pandemic-eligibility:instructions'), language)}
+        </Paragraph>
+        <ol color="black">
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:1'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:2'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:3'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:4'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:5'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:6'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:7'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:8'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:9'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:10'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:11'), language)}</li>
+          </Text>
+          <Text color="black">
+            <li color="black">{translate(getCopy('pandemic-eligibility:12'), language)}</li>
+          </Text>
+        </ol>
       </Box>
       <Box style={{ position: 'relative' }}>
         <Box
@@ -74,23 +124,23 @@ const Introduction: React.FC = () => {
           }}
         />
         <Box pad={{ vertical: 'none', horizontal: 'medium' }}>
-          <Paragraph color="black" fill={true}>
-            <Text color="black" weight={600}>
-              {translate(getCopy('warning'), language)}:
-            </Text>
-            <br />
+          <Heading level={4} color="black" margin={{ top: 'small', bottom: 'none' }}>
+            {translate(getCopy('warning'), language)}
+          </Heading>
+          <Paragraph color="black" fill={true} margin={{ bottom: 'small' }}>
             {translate(getCopy('warning:content-1'), language)}
-            <br />
-            <br />
+          </Paragraph>
+          <Paragraph color="black" fill={true} margin={{ top: 'small' }}>
             {translate(getCopy('warning:content-2'), language)}
           </Paragraph>
         </Box>
       </Box>
       <Box pad="medium">
-        <Paragraph fill={true} color="black">
-          <Text weight={600}>{translate(getCopy('agreement:header'), language)}</Text>
-          <br />
-          <Text weight={400}>{translate(getCopy('agreement:instructions'), language)}</Text>
+        <Heading level={4} color="black" margin={{ bottom: 'xsmall' }}>
+          {translate(getCopy('agreement:header'), language)}
+        </Heading>
+        <Paragraph color="black" fill={true} margin={{ vertical: 'none' }}>
+          {translate(getCopy('agreement:instructions'), language)}
         </Paragraph>
       </Box>
     </>


### PR DESCRIPTION
This PR just removes the DOM nesting errors due to `ol/ul` elements underneath `p` elements.

I also moved over to `Paragraph` components with `margin` adjustments instead of `br`. Text got a bit more condensed in places, but we could adjust that.

| Before | After |
| --- | --- |
| ![papua usdigitalresponse org_](https://user-images.githubusercontent.com/2907397/79626768-6ba50900-80e7-11ea-8c0c-2c939a9f86ff.png) | ![localhost_3000_ (2)](https://user-images.githubusercontent.com/2907397/79626756-57f9a280-80e7-11ea-8c02-9a4f6bbf918d.png) |

## Errors

These are the React errors this PR removes:

![image](https://user-images.githubusercontent.com/2907397/79626792-9f802e80-80e7-11ea-8e82-553438bffe0a.png)
