### PR TITLE
Update Sidebar to support rendering rectangular seals

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,10 +24,17 @@ const Sidebar: React.FC<Props> = (props) => {
   const { language, setLanguage } = useContext(LanguageContext)
 
   return (
-    <Card pad="medium" margin={{ left: 'small' }} textAlign="left" height="0%" background="white">
+    <Card
+      pad="medium"
+      margin={{ left: 'small' }}
+      textAlign="left"
+      height="0%"
+      background="white"
+      width={{ max: '350px' }}
+    >
       {seal && (
-        <Box height="175px" margin={{ bottom: 'medium' }}>
-          <Image src={seal} style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }} />
+        <Box margin={{ bottom: 'medium' }}>
+          <Image src={seal} style={{ maxHeight: '175px', maxWidth: '100%', objectFit: 'contain' }} />
         </Box>
       )}
       <Box>


### PR DESCRIPTION
We already have this branch on the `kansas` and `oregon` branches, but pulling into master. Previously, the seals would be rendered with a lot of margin as if they were square.

![image](https://user-images.githubusercontent.com/2907397/79909602-1bbd8f00-83d2-11ea-91f1-f23b70a52ca9.png)
