### PR TITLE
Update demo warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/validator": "^13.0.0",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
+    "colors": "^1.4.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-config-react": "^1.1.7",

--- a/public/form.sample.yml
+++ b/public/form.sample.yml
@@ -57,6 +57,96 @@ instructions:
         1. You have had to quit your job as a direct result of COVID-19.
         1. Your place of employment is closed as a direct result of the COVID-19 public health emergency.
         1. You work as an independent contractor with reportable income and are unemployed, partially employed, or unable or unavailable to work because the COVID-19 public health emergency has severely limited your ability to continue performing your customary work activities, and has thereby forced you to suspend such activities.
+    es: |-
+      ### Instrucciones
+
+      Bienvenido al {{STATE_CODE}} Sistema de reclamos de beneficios del seguro de desempleo.
+
+      La Solicitud de Reclamaciones de {{STATE_CODE}} Beneficios del Seguro de Desempleo debe usarse para solicitar beneficios de desempleo contra los ingresos obtenidos, o que se espera obtener, en el estado de {{STATE_CODE}}.
+
+      Los beneficios se pagan mediante depósito directo en su cuenta corriente o de ahorros. También puede optar por recibir una Tarjeta de pago electrónico (EPC) para acceder a sus beneficios.
+
+      #### Preparación
+
+      Tenga en cuenta que puede necesitar la siguiente información antes de presentar su reclamo:
+
+        - Su número de seguro social (SSN).
+        - Su ingreso bruto ajustado de su declaración de impuestos más reciente.
+        - Los nombres, direcciones, números de teléfono y fechas de empleo de todos los empleadores en los que ha trabajado en los últimos 18 meses.
+        - Su número de registro de extranjero, si corresponde.
+        - Los nombres, números de seguridad social y fechas de nacimiento de todos los hijos dependientes.
+        - Su licencia de conducir o número de identificación emitido por el estado.
+        - Su cuenta bancaria y número de ruta (si elige el depósito directo como su opción de pago).
+
+      #### Elegibilidad
+
+      El seguro de desempleo es un ingreso temporal:
+
+        - Para trabajadores elegibles
+        - Quienes pierden sus trabajos
+        - Sin culpa propia
+
+      Si ha trabajado en otro estado y no ha trabajado en {{STATE_CODE}} en los últimos 18 meses, debe comunicarse con la oficina de desempleo en los estados donde ha realizado el trabajo en los últimos 18 meses.
+
+      Para calificar para la Asistencia de desempleo pandémico, debe caer en al menos uno de los siguientes escenarios:
+
+        1. Le han diagnosticado COVID-19 o está experimentando síntomas de COVID-19 y está buscando un diagnóstico médico.
+        1. Ha tenido que renunciar a su trabajo debido a que entró en contacto directo con alguien que dio positivo por el coronavirus o que un profesional médico le diagnosticó COVID-19 y, siguiendo el consejo de un profesional médico calificado, debe renunciar a su cargo para poner en cuarentena.
+        1. Un miembro de su hogar ha sido diagnosticado con COVID-19.
+        1. Usted está brindando atención a un miembro de la familia o un miembro de su hogar ha sido diagnosticado con COVID-19.
+        1. Un niño u otra persona en el hogar para el cual tiene la responsabilidad principal de cuidar no puede asistir a la escuela u otra instalación que esté cerrada como resultado directo de la emergencia de salud pública de COVID-19 y se requiere dicha atención en la escuela o instalación trabajar.
+        1. No puede llegar al lugar de empleo debido a una cuarentena impuesta como resultado directo de la emergencia de salud pública COVID-19.
+        1. No puede llegar al lugar de empleo porque un proveedor de atención médica le ha aconsejado que se auto-ponga en cuarentena debido a preocupaciones relacionadas con COVID-19.
+        1. Estaba programado para comenzar a trabajar y no tiene trabajo o no puede acceder al trabajo como resultado directo de la emergencia de salud pública de COVID-19.
+        1. Se ha convertido en el sostén de la familia o el mayor apoyo de un hogar porque el jefe del hogar ha muerto como resultado directo de COVID-19.
+        1. Ha tenido que renunciar a su trabajo como resultado directo de COVID-19.
+        1. Su lugar de trabajo está cerrado como resultado directo de la emergencia de salud pública COVID-19.
+        1. Trabaja como un contratista independiente con ingresos declarables y está desempleado, parcialmente empleado o no puede o no está disponible para trabajar porque la emergencia de salud pública de COVID-19 ha limitado severamente su capacidad de continuar realizando sus actividades laborales habituales, y por lo tanto lo ha obligado a suspender tales actividades.
+    zh: |-
+      ###说明
+
+      欢迎使用{{STATE_CODE}}失业保险金索赔系统。
+
+      {{STATE_CODE}}失业保险金索赔申请表应用于针对处于{{STATE_CODE}}状态的已获得或预期获得的收入索取失业救济。
+
+      福利通过直接存款支付到您的支票或储蓄帐户中。您也可以选择接收电子支付卡（EPC）来获取您的权益。
+
+      ####准备
+
+      请注意，在提出索赔之前，您可能需要以下信息：
+
+        - 您的社会安全号码（SSN）。
+        - 您最近的纳税申报单上的调整后总收入。
+        - 您在过去18个月内工作过的所有雇主的姓名，地址，电话号码和工作日期。
+        - 您的外国人注册号（如果适用）。
+        - 所有受抚养子女的姓名，社会安全号码和出生日期。
+        - 您的驾驶执照或国家签发的身份证号。
+        - 您的银行帐户和银行帐号（如果您选择直接存款作为付款方式）。
+
+      ####资格
+
+      失业保险是临时收入：
+
+        - 对于合格的工人
+        - 谁丢了工作
+        - 通过自己没有过错
+
+      如果您在其他州工作，而在最近18个月内未在{{STATE_CODE}}工作，则必须与最近18个月从事工作的州的失业办公室联系。
+
+      为了获得大流行性失业援助的资格，您必须至少属于以下情况之一：
+
+        1. 您已被诊断出患有COVID-19或正在出现COVID-19的症状，并正在寻求医学诊断。
+        1. 您必须直接与经检测冠状病毒呈阳性或已被医学专家诊断为具有COVID-19的人直接接触，因此辞职，并在合格的医学健康专家的建议下，离职。必须辞职才能隔离。
+        1. 您的家庭成员已被诊断出COVID-19。
+        1. 您正在为被诊断患有COVID-19的家庭成员或家庭成员提供护理。
+        1. 由您承担主要护理责任的家庭中的儿童或其他人无法上学或直接由于COVID-19公共卫生紧急情况而关闭的其他设施，因此您需要进行此类学校或设施的护理上班。
+        1. 由于COVID-19公共卫生紧急事件的直接结果是隔离，您无法到达工作地点。
+        1. 您无法到达工作地点，因为由于与COVID-19有关的问题，卫生保健提供者建议您进行自我检疫。
+        1. 由于COVID-19公共卫生突发事件，您原本打算开始工作，没有工作或无法找到工作。
+        1. 您已成为家庭的养家糊口或主要支持，因为户主因COVID-19的直接死亡而死亡。
+        1. 由于COVID-19的直接结果，您不得不辞职。
+        1. 由于COVID-19公共卫生突发事件的直接结果，您的工作单位被关闭。
+        1. 您以可报告收入的独立承包商的身份工作，由于COVID-19公共卫生突发事件严重限制了您继续进行常规工作活动的能力，因此失业，半就业，无法工作或无力工作。暂停此类活动。
   warning:
     en: |-
       #### Warning
@@ -132,10 +222,11 @@ instructions:
       所有部分均通过验证后，请选择“提交”以完成您的索赔。除非您单击下面的“提交”，否则不会提出您的索赔。
   demo-warning:
     en: |-
-      This is for demo purposes only. Email [pua-requests@usdigitalresponse.org](mailto:pua-requests@usdigitalresponse.org) to learn more.
+      This is a simplified Pandemic Unemployment Assistance sample application that captures the minimum required data and helps users submit a clean claim. Read [our blog post](https://medium.com/u-s-digital-response/what-states-must-do-about-pandemic-unemployment-assistance-e4a96b6c7db) or email [pua-requests@usdigitalresponse.org](mailto:pua-requests@usdigitalresponse.org) to learn more.
     es: |-
-      Esto es solo para fines de demostración. Envíe un correo electrónico a [pua-requests@usdigitalresponse.org](mailto:pua-requests@usdigitalresponse.org) para obtener más información.
-    zh: '这仅用于演示目的。向[pua-requests@usdigitalresponse.org](mailto：pua-requests@usdigitalresponse.org)发送电子邮件以了解更多信息。'
+      Esta es una aplicación simplificada de muestra de Asistencia de desempleo pandémico que captura los datos mínimos requeridos y ayuda a los usuarios a presentar un reclamo limpio. Lea [nuestra publicación de blog](https://medium.com/us-digital-response/what-states-must-do-about-pandemic-unemployment-assistance-e4a96b6c7db) o envíe un correo electrónico [pua-requests@usdigitalresponse.org](mailto:pua-requests@usdigitalresponse.org) para obtener más información.
+    zh: |-
+      这是一个简化的大流行性失业援助示例应用程序，可捕获所需的最少数据并帮助用户提交明确的索赔要求。阅读[我们的博客文章](https://medium.com/us-digital-response/what-states-must-do-about-pandemic-unemployment-assistance-e4a96b6c7db)或发送电子邮件至[pua-requests@usdigitalresponse.org](mailto：pua-requests@usdigitalresponse.org)了解更多信息。
   back:
     en: Go Back
     es: Regresa

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -27,12 +27,17 @@ const FormApp: React.FC<{}> = () => {
   const onClickBack = () => setPage(pageIndex - 1)
 
   return (
-    <Box align="center" pad="medium" direction="column">
-      <Card margin={{ bottom: 'small' }} pad="small" background="white">
+    <Box align="center" pad="medium" direction="column" width={{ max: '1200px' }} margin="auto">
+      <Card
+        margin={{ bottom: 'small' }}
+        pad={{ horizontal: 'medium', vertical: 'small' }}
+        background="white"
+        width={{ max: '600px' }}
+      >
         <Markdown>{translateByID('demo-warning')}</Markdown>
       </Card>
       <Box width="100%" height="100%" justify="center" direction="row">
-        <Card width="50%" background="white" display="flex" justify="between" flexDirection="column" textAlign="left">
+        <Card background="white" justify="between" flex={{ grow: 1, shrink: 1 }}>
           {pageComponents[pageIndex]}
           <Box justify="between" pad="medium" direction="row">
             {(pageIndex > 0 && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -24,14 +24,7 @@ const Sidebar: React.FC<Props> = (props) => {
   const percent = Math.floor(((pageIndex + 1) / pages.length) * 100)
 
   return (
-    <Card
-      margin={{ left: 'small' }}
-      textAlign="left"
-      height="0%"
-      background="white"
-      pad="medium"
-      width={{ max: '350px' }}
-    >
+    <Card flex={{ shrink: 0 }} margin={{ left: 'small' }} height="0%" background="white" pad="medium" width="350px">
       {form.seal && (
         <Box margin={{ bottom: 'medium' }}>
           <Image src={form.seal} style={{ maxHeight: '175px', maxWidth: '100%', objectFit: 'contain' }} />

--- a/src/components/helper-components/Card.tsx
+++ b/src/components/helper-components/Card.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Box } from 'grommet'
+import { Box, BoxProps } from 'grommet'
 
-const Card: React.FC<any> = (props) => {
+const Card: React.FC<BoxProps> = (props) => {
   const { children, ...otherProps } = props
   return (
     <Box

--- a/src/components/helper-components/Markdown.tsx
+++ b/src/components/helper-components/Markdown.tsx
@@ -53,6 +53,9 @@ export const Markdown: React.FC<Props> = ({ margin, size, children }) => {
             component: Paragraph,
             props: merge({ fill: true, color: 'black', size: 'small' }, { margin, size }),
           },
+          a: {
+            props: { target: '_blank' },
+          },
         },
         ...headings
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4764,6 +4764,11 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
+colors@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"


### PR DESCRIPTION
This PR:
- Updates the demo copy to resolve https://github.com/usdigitalresponse/project-papua/issues/82
- Reduces the form padding on mobile devices (ala https://github.com/usdigitalresponse/project-papua/issues/5)
- Improves the error handling in `translate.js` for two common errors I've hit
- Updates markdown links to open in new tabs

Updated demo warning copy:

![image](https://user-images.githubusercontent.com/2907397/80137253-d7f49200-8557-11ea-9ca6-6d0e8a66d6c8.png)
