### PR TITLE
Improve Mobile Responsiveness (Part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Pilot Application for Pandemic Unemployment Assistance (PAPUA) project is a prototype service providing a unified unemployment intake form and delivers validated unemployment claims to various State backends. This project is a volunteer-led effort and part of the [US Digital Response network.][1]
 
-Give it a spin at https://papua.usdigitalresponse.org, or deploy it to your own AWS account in under 5 mins [with one click.](#deploying) 
+Give it a spin at https://papua.usdigitalresponse.org, or deploy it to your own AWS account in under 5 mins [with one click.](#deploying)
 ![](./media/validation.gif)
 
 ## Features
@@ -12,7 +12,7 @@ Give it a spin at https://papua.usdigitalresponse.org, or deploy it to your own 
 - A transform function converts the json to csv and re-uploads, in batches.
 - The state writes a script to load the converted s3 into whatever environment they need.
 - Minimal deployment overhead
-- intellisense for form.yml fields makes editing a breeze 
+- intellisense for form.yml fields makes editing a breeze
 
 # Technical overview
 
@@ -66,7 +66,9 @@ aws s3 --endpoint-url=http://localhost:4572 cp s3://papua-data-123456789/claims/
 ```
 
 # Deploying
+
 Requirements:
+
 - GitHub account
 - AWS account
 

--- a/public/form.sample.yml
+++ b/public/form.sample.yml
@@ -747,14 +747,10 @@ pages:
                     zh: 没有残疾的老兵
                   id: no-disability
                 - name:
-                    en: Veteran with Service-Connected Disability rated at less than 30%?
-                    es: ¿Veterano con discapacidad relacionada con el servicio calificado en menos del 30%?
-                    zh: 退伍军人的服务相关残障率低于30％？
+                    en: Veteran with Service-Connected Disability rated at less than 30%
                   id: disability-less-than-30
                 - name:
-                    en: Veteran with Service-Connected Disability rated at 30% or more?
-                    es: ¿Veterano con discapacidad relacionada con el servicio con una calificación del 30% o más?
-                    zh: 具有与服务有关的残疾的退伍军人的评分达到或超过30％？
+                    en: Veteran with Service-Connected Disability rated at 30% or more
                   id: disability-more-than-30
             - name:
                 en: Have you performed active military service during the last 2 years?
@@ -1112,6 +1108,13 @@ pages:
         id: employer-first-day-of-work
         required: true
         type: date
+        validate:
+          - type: max
+            value: 'id:employer-last-day-of-work'
+            error:
+              en: Start date must be before end date.
+              es: La fecha de inicio debe ser anterior a la fecha de finalización.
+              zh: 开始日期必须早于结束日期。
       - name:
           en: Last actual Day of Work
           es: Último día real de trabajo
@@ -1123,6 +1126,13 @@ pages:
         id: employer-last-day-of-work
         required: true
         type: date
+        validate:
+          - type: min
+            value: 'id:employer-first-day-of-work'
+            error:
+              en: End date must be after start date.
+              es: La fecha de finalización debe ser posterior a la fecha de inicio.
+              zh: 结束日期必须晚于开始日期。
       - name:
           en: 'Did you work for this employer full-time, part-time or on a staggered schedule?'
           es: '¿Trabajó para este empleador a tiempo completo, a tiempo parcial o en un horario escalonado?'

--- a/public/form.sample.yml
+++ b/public/form.sample.yml
@@ -134,6 +134,12 @@ instructions:
     en: Please upload a valid file.
     es: Sube un archivo válido.
     zh: 请上传有效文件。
+  invalid-address:
+    en: Please enter a valid address.
+  invalid-checkbox:
+    en: You must agree before continuing.
+    es: Debe aceptar antes de continuar.
+    zh: 您必须先同意才能继续。
   file-uploader-drag-drop:
     en: Drag and drop files here
     es: Arrastra y suelta archivos aquí
@@ -150,10 +156,6 @@ instructions:
     en: Uploaded!
     es: Subido!
     zh: 已上传！
-  invalid-checkbox:
-    en: You must agree before continuing.
-    es: Debe aceptar antes de continuar.
-    zh: 您必须先同意才能继续。
   confirmation-heading:
     en: Your application has been submitted!
     es: ¡Tu solicitud ha sido enviada!

--- a/public/form.sample.yml
+++ b/public/form.sample.yml
@@ -72,6 +72,8 @@ instructions:
     en: Progress
     es: Progreso
     zh: 进展
+  section:
+    en: Section
   complete:
     en: complete
     es: completar

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
     <link rel="icon" href="%PUBLIC_URL%/favicon/favicon.ico" />
     <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/favicon/apple-icon-57x57.png" />

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
 
+html {
+  background: #e5e5e5;
+}
+
 .App {
   background-color: #e5e5e5;
   width: 100%;

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { Page } from '../lib/types'
-import { Box, Heading } from 'grommet'
+import { Box, Heading, ResponsiveContext } from 'grommet'
 import Question from './Question'
 import { FormContext } from '../contexts/form'
 import { Markdown } from './helper-components/Markdown'
@@ -12,9 +12,11 @@ interface Props {
 const Form: React.FC<Props> = (props) => {
   const { page } = props
   const { translateCopy } = useContext(FormContext)
+  const size = useContext(ResponsiveContext)
 
+  const padding = size === 'small' ? '12px' : '24px'
   return (
-    <Box pad={{ horizontal: '48px', top: '48px', bottom: 'none' }} direction="column" justify="start">
+    <Box pad={{ horizontal: padding, top: padding, bottom: 'none' }} direction="column" justify="start">
       <Heading color="black" margin="none" level={3}>
         {translateCopy(page.heading)}
       </Heading>

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -60,7 +60,7 @@ const FormApp: React.FC<{}> = () => {
       >
         <Markdown>{translateByID('demo-warning')}</Markdown>
       </Card>
-      <Box width="100%" height="100%" justify="center" direction="row">
+      <Box width="100%" height="100%" justify="center" direction={size === 'small' ? 'column' : 'row'}>
         <Card pad="medium" background="white" justify="between" flex={{ grow: 1, shrink: 1 }}>
           {(claimID && <Confirmation id={claimID} />) || (
             <>
@@ -90,8 +90,7 @@ const FormApp: React.FC<{}> = () => {
             </>
           )}
         </Card>
-        {/* TODO: bring me back on mobile! */}
-        {size !== 'small' && <Sidebar pages={pageTitles} />}
+        <Sidebar pages={pageTitles} />
       </Box>
     </Box>
   )

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -54,14 +54,14 @@ const FormApp: React.FC<{}> = () => {
     <Box align="center" pad="medium" direction="column" width={{ max: '1200px' }} margin="auto">
       <Card
         margin={{ bottom: 'small' }}
-        pad={{ horizontal: 'medium', vertical: 'small' }}
+        pad={{ horizontal: size === 'small' ? '24px' : 'medium', vertical: 'small' }}
         background="white"
         width={{ max: '600px' }}
       >
         <Markdown>{translateByID('demo-warning')}</Markdown>
       </Card>
       <Box width="100%" height="100%" justify="center" direction="row">
-        <Card background="white" justify="between" flex={{ grow: 1, shrink: 1 }}>
+        <Card pad="medium" background="white" justify="between" flex={{ grow: 1, shrink: 1 }}>
           {(claimID && <Confirmation id={claimID} />) || (
             <>
               {pageComponents[pageIndex]}
@@ -90,6 +90,7 @@ const FormApp: React.FC<{}> = () => {
             </>
           )}
         </Card>
+        {/* TODO: bring me back on mobile! */}
         {size !== 'small' && <Sidebar pages={pageTitles} />}
       </Box>
     </Box>

--- a/src/components/FormApp.tsx
+++ b/src/components/FormApp.tsx
@@ -22,6 +22,12 @@ const FormApp: React.FC<{}> = () => {
   const onSubmit = async () => {
     setCanSubmit(false)
     try {
+      /**
+       * TODO: clear any subquestion values if the subquestion is hidden, s.t. we don't submit those values.
+       *
+       * We should only do this at submission time, so that users can toggle switches without losing
+       * their WIP content.
+       */
       const resp = await API.post('resolverAPI', '/claims', {
         body: {
           metadata: {

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -31,12 +31,8 @@ const Question: React.FC<Props> = (props) => {
             margin="none"
           >
             {translateCopy(question.name)}
+            {question.required && <span style={{ color: '#FF4040' }}> *</span>}
           </Heading>
-          {question.required && (
-            <Heading level={4} margin="none" color="#FF4040">
-              *
-            </Heading>
-          )}
         </Box>
         {question.instructions && (
           <Markdown margin={{ vertical: 'xsmall' }} size="small">

--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react'
-import { Box, Heading } from 'grommet'
+import { Box, Heading, ResponsiveContext } from 'grommet'
 import { FormContext } from '../contexts/form'
 import Summary from './Summary'
 import { Markdown } from './helper-components/Markdown'
@@ -12,14 +12,16 @@ interface Props {
 const Review: React.FC<Props> = (props) => {
   const { pages } = props
   const { values, translateByID, setPage } = useContext(FormContext)
+  const size = useContext(ResponsiveContext)
 
+  const padding = size === 'small' ? '12px' : '24px'
   return (
-    <Box pad="48px">
-      <Heading margin="none" level={3}>
+    <Box pad={{ horizontal: padding, top: padding, bottom: 'none' }} direction="column" justify="start">
+      <Heading color="black" margin="none" level={3}>
         {translateByID('submit')}
       </Heading>
 
-      <Markdown>{translateByID('submit-instructions')}</Markdown>
+      <Markdown size="small">{translateByID('submit-instructions')}</Markdown>
 
       <Summary setPage={setPage} values={values} pages={pages} />
     </Box>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { Card } from './helper-components'
-import { Box, Text, Select, Image } from 'grommet'
+import { Box, Text, Select, Image, ResponsiveContext } from 'grommet'
 import { LanguageContext } from '../contexts/language'
 import { FormContext } from '../contexts/form'
 import { range } from 'lodash'
@@ -19,12 +19,25 @@ const Sidebar: React.FC<Props> = (props) => {
   const { pages } = props
   const { translateByID, form, pageIndex, setPage, completion } = useContext(FormContext)
   const { language, setLanguage } = useContext(LanguageContext)
+  const size = useContext(ResponsiveContext)
 
   const currentPage = pages[pageIndex]
   const percent = Math.floor((pageIndex / (pages.length - 1)) * 100)
 
+  const canClickPage = (i: number) => {
+    // Always set to true right now for demo purposes
+    return true || range(0, i).every((index) => completion[index])
+  }
+
   return (
-    <Card flex={{ shrink: 0 }} margin={{ left: 'small' }} height="0%" background="white" pad="medium" width="350px">
+    <Card
+      flex={{ shrink: 0 }}
+      margin={size === 'small' ? { top: 'small' } : { left: 'small' }}
+      height="0%"
+      background="white"
+      pad="medium"
+      width={size === 'small' ? '100%' : '350px'}
+    >
       {form.seal && (
         <Box margin={{ bottom: 'medium' }}>
           <Image src={form.seal} style={{ maxHeight: '175px', maxWidth: '100%', objectFit: 'contain' }} />
@@ -62,22 +75,39 @@ const Sidebar: React.FC<Props> = (props) => {
         </Box>
       </Box>
       <Box margin={{ top: 'small' }}>
-        {pages.map((page, i) => {
-          // Set to true right now for demo purposes
-          const canClickPage =
-            true || i === 0 || i === pages.length - 1 || range(1, i).every((index) => completion[index])
-          return (
-            <Text
-              style={{ cursor: canClickPage ? 'pointer' : 'not-allowed' }}
-              onClick={() => canClickPage && setPage(i)}
-              color={currentPage === page ? 'black' : '#66788A'}
-              margin={{ bottom: 'xsmall' }}
-              key={page}
-            >
-              {page}
+        {size === 'small' ? (
+          <>
+            {/* On small screens, we collapse the section titles to a Select */}
+            <Text weight={600} color="black">
+              {translateByID('section')}
             </Text>
-          )
-        })}
+            <Select
+              a11yTitle="select section"
+              margin={{ top: 'xsmall' }}
+              options={pages.map((page, i) => ({ page, i, disabled: !canClickPage(i) }))}
+              labelKey="page"
+              valueKey={{ key: 'i', reduce: true }}
+              disabledKey="disabled"
+              value={pageIndex as any} /* These type definitions don't support values as numbers */
+              onChange={({ value: i }) => canClickPage(i) && setPage(i)}
+            />
+          </>
+        ) : (
+          /* On larger screens, we show all section titles as a list */
+          pages.map((page, i) => {
+            return (
+              <Text
+                style={{ cursor: canClickPage ? 'pointer' : 'not-allowed' }}
+                onClick={() => canClickPage && setPage(i)}
+                color={currentPage === page ? 'black' : '#66788A'}
+                margin={{ bottom: 'xsmall' }}
+                key={page}
+              >
+                {page}
+              </Text>
+            )
+          })
+        )}
       </Box>
     </Card>
   )

--- a/src/components/form-components/DatePicker.tsx
+++ b/src/components/form-components/DatePicker.tsx
@@ -24,22 +24,33 @@ const DatePicker: React.FC<{ question: Question }> = (props) => {
     v = m.add(offset, 'minutes').toDate()
   }
 
-  return (
-    <ReactDatePicker
-      className="date-picker"
-      onChange={(date) => {
-        setValue(
-          question,
-          moment
-            .utc(date as Date)
-            .startOf('day')
-            .format('YYYY-MM-DDTHH:mm:ssZ')
-        )
-      }}
-      value={v}
-      clearIcon={null}
-    />
-  )
+  const onChange = (date: Date | Date[]) => {
+    if (!date) {
+      setValue(question, undefined)
+    }
+
+    let d = moment.utc(date as Date)
+    if (d.years() > 999) {
+      // We don't care about the hour component, so we truncate to the start
+      // of the day. However, we ONLY do this once the user has finished typing in
+      // the year. Otherwise, it makes the day jump around.
+      // Effectively, we want to wait until they've finished typing in a date before
+      // truncating it down to the value we'll store.
+      d = d.startOf('day')
+    }
+    setValue(question, d.format('YYYY-MM-DDTHH:mm:ssZ'))
+  }
+
+  /**
+   * TODO:
+   * - Would be nice if delete moved your cursor to the previous date chunk
+   *   for example, pressing delete again after having deleted the year
+   *   should move your cursor to the end of your day value.
+   * - On mobile, the keyboard pops up. Good/bad??
+   * - On defocus, the calendar needs to hide.
+   */
+
+  return <ReactDatePicker className="date-picker" onChange={onChange} value={v} clearIcon={null} />
 }
 
 export default DatePicker

--- a/src/components/form-components/Number.tsx
+++ b/src/components/form-components/Number.tsx
@@ -31,7 +31,6 @@ export const Number: React.FC<Props> = (props) => {
     typeProps = {
       ...typeProps,
       decimalScale: 0,
-      thousandSeparator: true,
     }
   } else if (question.type === 'decimal') {
     typeProps = {

--- a/src/components/form-components/TextInput.tsx
+++ b/src/components/form-components/TextInput.tsx
@@ -15,7 +15,7 @@ const TextInput: React.FC<Props> = (props) => {
   const hasError = Boolean(errors[question.id])
   return (
     <GrommetTextInput
-      value={value as string}
+      value={(value as string) || ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(question, e.target.value)}
       color="black"
       style={{ border: hasError ? '#FF4040 1px solid' : 'black 1px solid' }}

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -191,118 +191,118 @@ export const FormProvider: React.FC = (props) => {
    * This hook is purely for testing, where it'll prefill form values so we can test
    * functionality later on in the form.
    */
-  const [prefilled, setPrefilled] = useState(false)
-  useEffect(() => {
-    if (prefilled || !form || process.env.NODE_ENV !== 'development') return
+  // const [prefilled, setPrefilled] = useState(false)
+  // useEffect(() => {
+  //   if (prefilled || !form || process.env.NODE_ENV !== 'development') return
 
-    // Initialize form with some starter values for testing.
-    // Note Number values won't render, but the value is there.
-    const testValues = {
-      /* eslint-disable @typescript-eslint/camelcase */
-      agreement: true,
-      first_name: 'Colin',
-      last_name: 'King',
-      dob: '2001-01-02T00:00:00+00:00',
-      gender: 'male',
-      race: 'white',
-      ethnicity: 'hispanic',
-      home_address: '123 Home St.',
-      telephone: 1234567890,
-      preferred_language: 'en',
-      mailing_home_address_same: true,
-      ssn: 123456789,
-      ssn_confirm: 123456789,
-      has_dl_or_state_id: false,
-      is_us_citizen: true,
-      'military-veteran': true,
-      'active-duty-start': '2020-05-06T00:00:00+00:00',
-      'active-duty-end': '2020-05-22T00:00:00+00:00',
-      'military-disability': 'disability-more-than-30',
-      'military-active-last-two-years': true,
-      'military-last-pay-grade': '12345',
-      'military-accured-paid-leave': 12345,
-      'military-reason-for-separation': '123',
-      'military-branch': 'army',
-      'military-work-end': '2020-04-29T00:00:00+00:00',
-      'military-character-of-service': 'Test',
-      'military-net-service': '123',
-      'last-week-paid': 12345,
-      'employment-current-status': true,
-      'last-week-hours': 1234,
-      'employment-able-to-work': true,
-      'employment-option-to-telework': true,
-      'employment-available-to-work': true,
-      'employment-last-12-months': true,
-      'employment-employers-in-last-18-months': '5-or-more',
-      'employment-federal-employee': true,
-      'employment-federal-employee-last-date': '2020-05-27T00:00:00+00:00',
-      'employment-in-trade-union': true,
-      'employment-trade-union': '1033',
-      'employer-name': 'Another One',
-      'employer-address': '123456 Test',
-      'employer-phone-number': 1234567890,
-      'employer-id-number': 1234567890,
-      'employer-job-title': 'Testing Engineer',
-      'employer-first-day-of-work': '2020-05-19T00:00:00+00:00',
-      'employer-last-day-of-work': '2020-04-29T00:00:00+00:00',
-      'employer-type': 'fulltime',
-      'employer-pay-rate': 12345678,
-      'employer-pay-unit': 'per-hour',
-      'employer-reason-for-separation': true,
-      'covid-19-reason': 'household_diagnosed',
-      'employer-current-benefits': true,
-      'employer-current-teleworking': true,
-      'tax-info-have-tax-return': true,
-      'tax-info-married': 'married-jointly',
-      'tax-info-agi': 12345678,
-      'tax-info-dependents': '2',
-      'unemployment-in-another-state': true,
-      'unemployment-in-another-state-state': 'ak',
-      'unemployment-in-another-state-date': '2020-05-20T00:00:00+00:00',
-      'unemployment-in-another-state-employment-since': true,
-      'other-income-public-assistance': true,
-      'other-income-dhs-work': false,
-      'other-income-snap': false,
-      'other-income-temp-disability-insurance': false,
-      'other-income-workers-comp': false,
-      'other-income-disability-payments': false,
-      'other-income-retirement-pension': true,
-      'other-income-retirement annuity': true,
-      'other-income-social-security': false,
-      'payment-income-withheld': 'state-and-fed',
-      'payment-option': 'direct-deposit',
-      'payment-bank-name': 'Yees',
-      'payment-account-type': 'savings',
-      'payment-account-number': 1234567890,
-      'payment-account-number-confirm': 1234567890,
-      'payment-routing-number': 23456789,
-      'payment-routing-number-confirm': 23456789,
-    }
-    for (const [id, v] of Object.entries(testValues)) {
-      if (values[id] === v) {
-        continue
-      }
+  //   // Initialize form with some starter values for testing.
+  //   // Note Number values won't render, but the value is there.
+  //   const testValues = {
+  //     /* eslint-disable @typescript-eslint/camelcase */
+  //     agreement: true,
+  //     first_name: 'Colin',
+  //     last_name: 'King',
+  //     dob: '2001-01-02T00:00:00+00:00',
+  //     gender: 'male',
+  //     race: 'white',
+  //     ethnicity: 'hispanic',
+  //     home_address: '123 Home St.',
+  //     telephone: 1234567890,
+  //     preferred_language: 'en',
+  //     mailing_home_address_same: true,
+  //     ssn: 123456789,
+  //     ssn_confirm: 123456789,
+  //     has_dl_or_state_id: false,
+  //     is_us_citizen: true,
+  //     'military-veteran': true,
+  //     'active-duty-start': '2020-05-06T00:00:00+00:00',
+  //     'active-duty-end': '2020-05-22T00:00:00+00:00',
+  //     'military-disability': 'disability-more-than-30',
+  //     'military-active-last-two-years': true,
+  //     'military-last-pay-grade': '12345',
+  //     'military-accured-paid-leave': 12345,
+  //     'military-reason-for-separation': '123',
+  //     'military-branch': 'army',
+  //     'military-work-end': '2020-04-29T00:00:00+00:00',
+  //     'military-character-of-service': 'Test',
+  //     'military-net-service': '123',
+  //     'last-week-paid': 12345,
+  //     'employment-current-status': true,
+  //     'last-week-hours': 1234,
+  //     'employment-able-to-work': true,
+  //     'employment-option-to-telework': true,
+  //     'employment-available-to-work': true,
+  //     'employment-last-12-months': true,
+  //     'employment-employers-in-last-18-months': '5-or-more',
+  //     'employment-federal-employee': true,
+  //     'employment-federal-employee-last-date': '2020-05-27T00:00:00+00:00',
+  //     'employment-in-trade-union': true,
+  //     'employment-trade-union': '1033',
+  //     'employer-name': 'Another One',
+  //     'employer-address': '123456 Test',
+  //     'employer-phone-number': 1234567890,
+  //     'employer-id-number': 1234567890,
+  //     'employer-job-title': 'Testing Engineer',
+  //     'employer-first-day-of-work': '2020-05-19T00:00:00+00:00',
+  //     'employer-last-day-of-work': '2020-04-29T00:00:00+00:00',
+  //     'employer-type': 'fulltime',
+  //     'employer-pay-rate': 12345678,
+  //     'employer-pay-unit': 'per-hour',
+  //     'employer-reason-for-separation': true,
+  //     'covid-19-reason': 'household_diagnosed',
+  //     'employer-current-benefits': true,
+  //     'employer-current-teleworking': true,
+  //     'tax-info-have-tax-return': true,
+  //     'tax-info-married': 'married-jointly',
+  //     'tax-info-agi': 12345678,
+  //     'tax-info-dependents': '2',
+  //     'unemployment-in-another-state': true,
+  //     'unemployment-in-another-state-state': 'ak',
+  //     'unemployment-in-another-state-date': '2020-05-20T00:00:00+00:00',
+  //     'unemployment-in-another-state-employment-since': true,
+  //     'other-income-public-assistance': true,
+  //     'other-income-dhs-work': false,
+  //     'other-income-snap': false,
+  //     'other-income-temp-disability-insurance': false,
+  //     'other-income-workers-comp': false,
+  //     'other-income-disability-payments': false,
+  //     'other-income-retirement-pension': true,
+  //     'other-income-retirement annuity': true,
+  //     'other-income-social-security': false,
+  //     'payment-income-withheld': 'state-and-fed',
+  //     'payment-option': 'direct-deposit',
+  //     'payment-bank-name': 'Yees',
+  //     'payment-account-type': 'savings',
+  //     'payment-account-number': 1234567890,
+  //     'payment-account-number-confirm': 1234567890,
+  //     'payment-routing-number': 23456789,
+  //     'payment-routing-number-confirm': 23456789,
+  //   }
+  //   for (const [id, v] of Object.entries(testValues)) {
+  //     if (values[id] === v) {
+  //       continue
+  //     }
 
-      for (const [i, page] of form.pages.entries()) {
-        for (const question of getFlattenedQuestions(page.questions, values)) {
-          if (question.id === id) {
-            if (i !== pageIndex) {
-              setPageIndex(i)
-              // 1337 hacks
-              return
-            }
+  //     for (const [i, page] of form.pages.entries()) {
+  //       for (const question of getFlattenedQuestions(page.questions, values)) {
+  //         if (question.id === id) {
+  //           if (i !== pageIndex) {
+  //             setPageIndex(i)
+  //             // 1337 hacks
+  //             return
+  //           }
 
-            setValue(question, v)
-            // 1337 hacks
-            return
-          }
-        }
-      }
-    }
+  //           setValue(question, v)
+  //           // 1337 hacks
+  //           return
+  //         }
+  //       }
+  //     }
+  //   }
 
-    // now that we've prefilled the values, stop overwriting them with the initial values.
-    setPrefilled(true)
-  })
+  //   // now that we've prefilled the values, stop overwriting them with the initial values.
+  //   setPrefilled(true)
+  // })
 
   useEffect(() => {
     if (form) {

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -188,6 +188,49 @@ export const FormProvider: React.FC = (props) => {
   }
 
   useEffect(() => {
+    if (!form) return
+
+    // Initialize form with some starter values for testing.
+    const testValues = {
+      /* eslint-disable @typescript-eslint/camelcase */
+      agreement: true,
+      first_name: 'Colin',
+      last_name: 'King',
+      dob: '2001-01-02T00:00:00+00:00',
+      gender: 'male',
+      race: 'white',
+      ethnicity: 'hispanic',
+      home_address: '123 Home St.',
+      telephone: 1234567890,
+      preferred_language: 'en',
+    }
+    for (const [id, v] of Object.entries(testValues)) {
+      if (values[id] === v) {
+        continue
+      }
+
+      for (const [i, page] of form.pages.entries()) {
+        for (const question of getFlattenedQuestions(page.questions, values)) {
+          if (question.id === id) {
+            if (i !== pageIndex) {
+              setPageIndex(i)
+
+              // 1337 hacks
+              return
+            }
+
+            console.log('setting value', question, v, completion)
+            setValue(question, v)
+
+            // 1337 hacks
+            return
+          }
+        }
+      }
+    }
+  })
+
+  useEffect(() => {
     if (form) {
       // Update the page title
       document.title = translateCopy(form.title)

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -191,10 +191,12 @@ export const FormProvider: React.FC = (props) => {
    * This hook is purely for testing, where it'll prefill form values so we can test
    * functionality later on in the form.
    */
+  const [prefilled, setPrefilled] = useState(false)
   useEffect(() => {
-    if (!form || process.env.NODE_ENV !== 'development') return
+    if (prefilled || !form || process.env.NODE_ENV !== 'development') return
 
     // Initialize form with some starter values for testing.
+    // Note Number values won't render, but the value is there.
     const testValues = {
       /* eslint-disable @typescript-eslint/camelcase */
       agreement: true,
@@ -207,6 +209,74 @@ export const FormProvider: React.FC = (props) => {
       home_address: '123 Home St.',
       telephone: 1234567890,
       preferred_language: 'en',
+      mailing_home_address_same: true,
+      ssn: 123456789,
+      ssn_confirm: 123456789,
+      has_dl_or_state_id: false,
+      is_us_citizen: true,
+      'military-veteran': true,
+      'active-duty-start': '2020-05-06T00:00:00+00:00',
+      'active-duty-end': '2020-05-22T00:00:00+00:00',
+      'military-disability': 'disability-more-than-30',
+      'military-active-last-two-years': true,
+      'military-last-pay-grade': '12345',
+      'military-accured-paid-leave': 12345,
+      'military-reason-for-separation': '123',
+      'military-branch': 'army',
+      'military-work-end': '2020-04-29T00:00:00+00:00',
+      'military-character-of-service': 'Test',
+      'military-net-service': '123',
+      'last-week-paid': 12345,
+      'employment-current-status': true,
+      'last-week-hours': 1234,
+      'employment-able-to-work': true,
+      'employment-option-to-telework': true,
+      'employment-available-to-work': true,
+      'employment-last-12-months': true,
+      'employment-employers-in-last-18-months': '5-or-more',
+      'employment-federal-employee': true,
+      'employment-federal-employee-last-date': '2020-05-27T00:00:00+00:00',
+      'employment-in-trade-union': true,
+      'employment-trade-union': '1033',
+      'employer-name': 'Another One',
+      'employer-address': '123456 Test',
+      'employer-phone-number': 1234567890,
+      'employer-id-number': 1234567890,
+      'employer-job-title': 'Testing Engineer',
+      'employer-first-day-of-work': '2020-05-19T00:00:00+00:00',
+      'employer-last-day-of-work': '2020-04-29T00:00:00+00:00',
+      'employer-type': 'fulltime',
+      'employer-pay-rate': 12345678,
+      'employer-pay-unit': 'per-hour',
+      'employer-reason-for-separation': true,
+      'covid-19-reason': 'household_diagnosed',
+      'employer-current-benefits': true,
+      'employer-current-teleworking': true,
+      'tax-info-have-tax-return': true,
+      'tax-info-married': 'married-jointly',
+      'tax-info-agi': 12345678,
+      'tax-info-dependents': '2',
+      'unemployment-in-another-state': true,
+      'unemployment-in-another-state-state': 'ak',
+      'unemployment-in-another-state-date': '2020-05-20T00:00:00+00:00',
+      'unemployment-in-another-state-employment-since': true,
+      'other-income-public-assistance': true,
+      'other-income-dhs-work': false,
+      'other-income-snap': false,
+      'other-income-temp-disability-insurance': false,
+      'other-income-workers-comp': false,
+      'other-income-disability-payments': false,
+      'other-income-retirement-pension': true,
+      'other-income-retirement annuity': true,
+      'other-income-social-security': false,
+      'payment-income-withheld': 'state-and-fed',
+      'payment-option': 'direct-deposit',
+      'payment-bank-name': 'Yees',
+      'payment-account-type': 'savings',
+      'payment-account-number': 1234567890,
+      'payment-account-number-confirm': 1234567890,
+      'payment-routing-number': 23456789,
+      'payment-routing-number-confirm': 23456789,
     }
     for (const [id, v] of Object.entries(testValues)) {
       if (values[id] === v) {
@@ -218,20 +288,20 @@ export const FormProvider: React.FC = (props) => {
           if (question.id === id) {
             if (i !== pageIndex) {
               setPageIndex(i)
-
               // 1337 hacks
               return
             }
 
-            console.log('setting value', question, v, completion)
             setValue(question, v)
-
             // 1337 hacks
             return
           }
         }
       }
     }
+
+    // now that we've prefilled the values, stop overwriting them with the initial values.
+    setPrefilled(true)
   })
 
   useEffect(() => {

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -187,8 +187,12 @@ export const FormProvider: React.FC = (props) => {
     window.scrollTo(0, 0)
   }
 
+  /**
+   * This hook is purely for testing, where it'll prefill form values so we can test
+   * functionality later on in the form.
+   */
   useEffect(() => {
-    if (!form) return
+    if (!form || process.env.NODE_ENV !== 'development') return
 
     // Initialize form with some starter values for testing.
     const testValues = {

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -28,7 +28,6 @@ export function canContinue(page: Page, values: Values, errors: Errors): boolean
   const questions = getFlattenedQuestions(page.questions, values)
   const questionIds = questions.map((q) => q.id)
   const requiredQuestions = questions.filter((q) => q.required).map((q) => q.id)
-  console.log('required questions', questions, requiredQuestions, values, errors)
   return requiredQuestions.every((id) => values[id] !== undefined) && !questionIds.some((id) => errors[id])
 }
 

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -28,7 +28,8 @@ export function canContinue(page: Page, values: Values, errors: Errors): boolean
   const questions = getFlattenedQuestions(page.questions, values)
   const questionIds = questions.map((q) => q.id)
   const requiredQuestions = questions.filter((q) => q.required).map((q) => q.id)
-  return requiredQuestions.every((id) => values[id]) && !questionIds.some((id) => errors[id])
+  console.log('required questions', questions, requiredQuestions, values, errors)
+  return requiredQuestions.every((id) => values[id] !== undefined) && !questionIds.some((id) => errors[id])
 }
 
 /**
@@ -37,22 +38,19 @@ export function canContinue(page: Page, values: Values, errors: Errors): boolean
  * @param values
  */
 export function getFlattenedQuestions(questions: Question[], values: Values): Question[] {
-  let flattenedQuestions: Question[] = []
+  const flattenedQuestions: Question[] = []
 
-  questions.forEach((question) => {
+  for (const question of questions) {
     flattenedQuestions.push(question)
     const { id } = question
 
     const value = values[id] as string
-    const hasSubQuestions = value && question.switch && typeof value === 'string' && question.switch[value]
-
+    const hasSubQuestions = value !== undefined && question.switch && question.switch[value] !== undefined
     if (hasSubQuestions) {
       const subQuestions = question.switch![value]
-      flattenedQuestions = subQuestions
-        ? flattenedQuestions.concat(getFlattenedQuestions(subQuestions, values))
-        : flattenedQuestions
+      flattenedQuestions.push(...getFlattenedQuestions(subQuestions, values))
     }
-  })
+  }
 
   return flattenedQuestions
 }


### PR DESCRIPTION
This PR aims to improve the mobile responsiveness of the PAPUA app. It largely consists of bugfixes from issues I found while running through the app on my phone:

- Reduces padding around forms and the review page on mobile
- Removes zoom on input focus
- Fixes bug where the day would jump when typing in a year
- Brings the sidebar back on mobile and collapses the section titles as a Select
- Adds a missing instructional text for invalid addresses
- Adds first/last date validation to employer page
- Sets the html background color (so it isn't white)
- Attaches the required `*` to the end of the text in each question header, rather than off to the side on long questions that wrap.
- Fixes the `canContinue` logic after the validation changes I merged which allowed falsey values
- Fixes a `uncontrolled -> controlled` react bug in the TextInput
- Adds a helper (commented out, but you can uncomment it for local testing) that prefills some form data s.t. it is easier to look through the form without inserting data every time.

Known TODOs for future PR:
- Hide the keyboard on defocus of the datepicker input
- Clear hidden switch values on submission
- Improve value rendering in the review page
- Fix padding on file uploads when rendering on mobile
- TBD more mobile bug fixes

Known can't-dos:
- Ideally we can hide the keyboard when a user clicks on the date picker, but that appears to be unsupported and (from reading stack overflows of other date pickers) rather tricky to do regardless. It usually requires the use of the input `readonly` property. There might be better React libraries purpose-built for this.