### PR TITLE
Add support for github pages deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      # yarn install with caching
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install Dependencies
+        run: yarn install
+
       - name: Build for gh-pages
         run: yarn predeploy
       - name: deploy to gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,12 @@ jobs:
         run: |-
           yarn run --silent js-yaml ./public/form.yml > ./public/form.json
           yarn ajv validate -s ./src/form.schema.json -d ./public/form.json
+
+  deploy-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build for gh-pages
+        run: yarn predeploy
+      - name: deploy to gh-pages
+        run: yarn deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,27 +167,3 @@ jobs:
         run: |-
           yarn run --silent js-yaml ./public/form.yml > ./public/form.json
           yarn ajv validate -s ./src/form.schema.json -d ./public/form.json
-
-  deploy-gh-pages:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      # yarn install with caching
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Build for gh-pages
-        run: yarn predeploy
-      - name: deploy to gh-pages
-        run: yarn deploy

--- a/README.md
+++ b/README.md
@@ -142,8 +142,15 @@ const resp = await API.post('resolverAPI', '/claims', {
   },
 }). 
 ```
-
 6. [Optional] Configure a custom domain on github.com, found under Settings in your fork. [See the docs.][7] 
+7. To deploy:
+```bash
+yarn install
+yarn predeploy
+yarn deploy
+```
+
+Your form is now hosted at `https://<username>.github.io/<repository>/`
 
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ aws s3 --endpoint-url=http://localhost:4572 cp s3://papua-data-123456789/claims/
 ```
 
 # Deploying
-You can deploy the complete PAPUA service with AWS Amplify, or deploy the front-end form with Github Pages.  
+
+You can deploy the complete PAPUA service with AWS Amplify, or deploy the front-end form with Github Pages.
 
 ## Deploying with AWS Amplify
+
 Requirements:
 
 - GitHub account
@@ -115,6 +117,7 @@ At this point, you can now reboot your Lambda to pick up this environment change
 5. [Optional] Redirect a subdomain from your state's website to this Amplify app. [Docs][6]
 
 ## Deploying with Github Pages
+
 With this method, you'll be able to quickly get your form hosted without having to configure AWS infrastructure or custom backend components. This method is great for standing up a self-guided qualifaction wizard, or if you want to use PAPUA templating with a non-AWS backend.
 
 Requirements:
@@ -140,10 +143,12 @@ const resp = await API.post('resolverAPI', '/claims', {
     },
     questions: values,
   },
-}). 
+}).
 ```
-6. [Optional] Configure a custom domain on github.com, found under Settings in your fork. [See the docs.][7] 
+
+6. [Optional] Configure a custom domain on github.com, found under Settings in your fork. [See the docs.][7]
 7. To deploy:
+
 ```bash
 yarn install
 yarn predeploy
@@ -151,7 +156,6 @@ yarn deploy
 ```
 
 Your form is now hosted at `https://<username>.github.io/<repository>/`
-
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ aws s3 --endpoint-url=http://localhost:4572 cp s3://papua-data-123456789/claims/
 ```
 
 # Deploying
+You can deploy the complete PAPUA service with AWS Amplify, or deploy the front-end form with Github Pages.  
 
+## Deploying with AWS Amplify
 Requirements:
 
 - GitHub account
@@ -85,7 +87,7 @@ Your fork is now configured to auto-deploy the `master` branch to your Amplify d
 
 2. [Optional] Update the questions used in your state's PAPUA form by editing `forms.yml` and committing those changes to the `master` branch of your fork.
 
-3. [Optional] Update the state logo by dropping a `<state code>.png` file into `public` and commiting that change to the `master` branch of your fork.
+3. [Optional] Update the state logo by dropping a `<state code>.png` file into `public` and committing that change to the `master` branch of your fork.
 
 4. [Optional] By default, this system will produce an hourly CSV of claim submissions. If you want to customize this, you can implement a "transformer" which will write claims in batches into your state's system. You can do this by adding a file to `backend/functions/transformer/src/transformers/<state code>.ts` where `<state code>` is your state's two-letter state abbreviation (CA, OR, etc.).
 
@@ -110,13 +112,45 @@ You can this commit this file to the `master` branch in your fork, which will up
 
 At this point, you can now reboot your Lambda to pick up this environment change by clicking on your backend environment and selecting `Redeploy this version`.
 
-5. [Optional] Redirect a subdomain from your state's website to this Amplify app. [Docs](https://docs.aws.amazon.com/amplify/latest/userguide/custom-domains.html)
+5. [Optional] Redirect a subdomain from your state's website to this Amplify app. [Docs][6]
+
+## Deploying with Github Pages
+With this method, you'll be able to quickly get your form hosted without having to configure AWS infrastructure or custom backend components. This method is great for standing up a self-guided qualifaction wizard, or if you want to use PAPUA templating with a non-AWS backend.
+
+Requirements:
+
+- GitHub account
+
+1. Fork this repo
+2. Update the `predeploy` script found in `package.json` to `https://<username>.github.io/<repository>/`
+3. [Optional] Update the questions used in your state's PAPUA form by editing `forms.yml` and committing those changes to the `master` branch of your fork.
+4. [Optional] Update the state logo by dropping a `<state code>.png` file into `public` and committing that change to the `master` branch of your fork.
+5. [Optional] Update the API call. By default, PAPUA make a post request to an AWS endpoint, this will break with non-Amplify deployments.
+
+Remove or change the below code block to match your needs. (You can also remove the submit button altogether)
+
+```ts
+// src/components/FormApp.tsx
+const resp = await API.post('resolverAPI', '/claims', {
+  body: {
+    metadata: {
+      uuid: uuid(window.location.hostname, uuid.DNS),
+      timestamp: new Date(),
+      host: window.location.hostname,
+    },
+    questions: values,
+  },
+}). 
+```
+
+6. [Optional] Configure a custom domain on github.com, found under Settings in your fork. [See the docs.][7] 
+
 
 # Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for additional information.
 
-If you are editing a form ([`public/form.yml`](public/form.yml)), then consider using [VSCode](https://code.visualstudio.com/) with the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml). With this, you'll get syntax validation and intellisense while editing the form.
+If you are editing a form ([`public/form.yml`](public/form.yml)), then consider using [VSCode][8] with the [YAML extension][9]. With this, you'll get syntax validation and intellisense while editing the form.
 
 # License
 
@@ -127,3 +161,7 @@ If you are editing a form ([`public/form.yml`](public/form.yml)), then consider 
 [3]: https://docs.aws.amazon.com/AmazonS3/latest/dev/Welcome.html
 [4]: https://aws.amazon.com/lambda/
 [5]: https://docs.google.com/document/d/1Jntt7jOtc_5Qj4SP7GdC4u3Uyg9z_kU6jsm3CpCaeWU/edit?usp=sharing
+[6]: https://docs.aws.amazon.com/amplify/latest/userguide/custom-domains.html
+[7]: https://help.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site
+[8]: https://code.visualstudio.com/
+[9]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "project-papua-ts",
+  "homepage": "https://usdigitalresponse.github.io/project-papua",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -11,6 +12,7 @@
     "copy-to-clipboard": "^3.3.1",
     "email-validator": "^2.0.4",
     "express": "^4.17.1",
+    "gh-pages": "^2.2.0",
     "grommet": "^2.12.0",
     "grommet-icons": "^4.4.0",
     "js-yaml": "colinking/js-yaml#2a635bc6563d609c0124fcbdcb0ebcaf7dd12d40",
@@ -31,6 +33,8 @@
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
+    "predeploy": "yarn run build",
+    "deploy": "gh-pages -d build",
     "test": "jest --testPathIgnorePatterns 'backend/.*'",
     "eject": "react-scripts eject",
     "amplify:transformer": "FUNCTION_NAME=transformer scripts/compile-function.sh",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
-    "build-gh-pages": "SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=https://usdigitalresponse.github.io/project-papua/ react-scripts build",
-    "predeploy": "yarn run build-gh-pages",
+    "predeploy": "PUBLIC_URL=https://usdigitalresponse.github.io/project-papua/ yarn run build",
     "deploy": "gh-pages -d build",
     "test": "jest --testPathIgnorePatterns 'backend/.*'",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "project-papua-ts",
-  "homepage": "https://usdigitalresponse.github.io/project-papua",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -33,7 +32,8 @@
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
-    "predeploy": "yarn run build",
+    "build-gh-pages": "SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=https://usdigitalresponse.github.io/project-papua/ react-scripts build",
+    "predeploy": "yarn run build-gh-pages",
     "deploy": "gh-pages -d build",
     "test": "jest --testPathIgnorePatterns 'backend/.*'",
     "eject": "react-scripts eject",

--- a/public/form.sample.yml
+++ b/public/form.sample.yml
@@ -6,7 +6,7 @@ description:
   en: Demo of the USDR's Pandemic Unemployment Assistance service
   es: Demostración del servicio de asistencia de desempleo pandémico del USDR
   zh: USDR大流行性失业援助服务演示
-seal: /generic-state-seal.png
+seal: generic-state-seal.png
 variables:
   STATE_CODE: '[ST]'
   STATE_NAME: '[State]'

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -58,7 +58,7 @@ export const FormProvider: React.FC = (props) => {
       // TODO: experiment with nextjs to see if we can embed this file instead
       // of fetching it. This'll speed up page load. Next would allow us to
       // get the benefits of ejecting CRA without ejecting.
-      const [form, formSample] = await Promise.all([ky.get('/form.yml').text(), ky.get('/form.sample.yml').text()])
+      const [form, formSample] = await Promise.all([ky.get('./form.yml').text(), ky.get('./form.sample.yml').text()])
 
       let contents, sampleContents
       try {
@@ -82,6 +82,9 @@ export const FormProvider: React.FC = (props) => {
       // `form.yml`.
       const useSample = contents === null
       const rawForm = useSample ? sampleContents : contents
+      rawForm.seal = './generic-state-seal.png'
+      // rawForm.seal = '.' + rawForm.seal
+      console.log(rawForm)
 
       // During local development, we validate the form structure against
       // our JSON Schema and render any errors.

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -58,7 +58,10 @@ export const FormProvider: React.FC = (props) => {
       // TODO: experiment with nextjs to see if we can embed this file instead
       // of fetching it. This'll speed up page load. Next would allow us to
       // get the benefits of ejecting CRA without ejecting.
-      const [form, formSample] = await Promise.all([ky.get('./form.yml').text(), ky.get('./form.sample.yml').text()])
+      const [form, formSample] = await Promise.all([
+        ky.get('/project-papua/form.yml').text(),
+        ky.get('/project-papua/form.sample.yml').text(),
+      ])
 
       let contents, sampleContents
       try {

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -58,10 +58,7 @@ export const FormProvider: React.FC = (props) => {
       // TODO: experiment with nextjs to see if we can embed this file instead
       // of fetching it. This'll speed up page load. Next would allow us to
       // get the benefits of ejecting CRA without ejecting.
-      const [form, formSample] = await Promise.all([
-        ky.get('/project-papua/form.yml').text(),
-        ky.get('/project-papua/form.sample.yml').text(),
-      ])
+      const [form, formSample] = await Promise.all([ky.get('form.yml').text(), ky.get('form.sample.yml').text()])
 
       let contents, sampleContents
       try {
@@ -85,7 +82,6 @@ export const FormProvider: React.FC = (props) => {
       // `form.yml`.
       const useSample = contents === null
       const rawForm = useSample ? sampleContents : contents
-      rawForm.seal = `./project-papua/${rawForm.seal}`
 
       // During local development, we validate the form structure against
       // our JSON Schema and render any errors.

--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -82,9 +82,7 @@ export const FormProvider: React.FC = (props) => {
       // `form.yml`.
       const useSample = contents === null
       const rawForm = useSample ? sampleContents : contents
-      rawForm.seal = './generic-state-seal.png'
-      // rawForm.seal = '.' + rawForm.seal
-      console.log(rawForm)
+      rawForm.seal = `./project-papua/${rawForm.seal}`
 
       // During local development, we validate the form structure against
       // our JSON Schema and render any errors.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,7 +4047,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@^2.6.2:
+async@^2.6.1, async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -5215,7 +5215,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.19.0, commander@^2.20.0:
+commander@^2.11.0, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -6338,6 +6338,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+email-addresses@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.1.0.tgz#cabf7e085cbdb63008a70319a74e6136188812fb"
+  integrity sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==
+
 email-validator@*, email-validator@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-2.0.4.tgz#b8dfaa5d0dae28f1b03c95881d904d4e40bfe7ed"
@@ -7213,10 +7218,32 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+filename-reserved-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz#e61cf805f0de1c984567d0386dc5df50ee5af7e4"
+  integrity sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=
+
 filename-reserved-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
   integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify-url@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/filenamify-url/-/filenamify-url-1.0.0.tgz#b32bd81319ef5863b73078bed50f46a4f7975f50"
+  integrity sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=
+  dependencies:
+    filenamify "^1.0.0"
+    humanize-url "^1.0.0"
+
+filenamify@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-1.2.1.tgz#a9f2ffd11c503bed300015029272378f1f1365a5"
+  integrity sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=
+  dependencies:
+    filename-reserved-regex "^1.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
 
 filenamify@^2.0.0:
   version "2.1.0"
@@ -7625,6 +7652,18 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+gh-pages@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-2.2.0.tgz#74ebeaca8d2b9a11279dcbd4a39ddfff3e6caa24"
+  integrity sha512-c+yPkNOPMFGNisYg9r4qvsMIjVYikJv7ImFOhPIVPt0+AcRUamZ7zkGRLHz7FKB0xrlZ+ddSOJsZv9XAFVXLmA==
+  dependencies:
+    async "^2.6.1"
+    commander "^2.18.0"
+    email-addresses "^3.0.1"
+    filenamify-url "^1.0.0"
+    fs-extra "^8.1.0"
+    globby "^6.1.0"
 
 gifsicle@^4.0.0:
   version "4.0.1"
@@ -8204,6 +8243,14 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+humanize-url@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/humanize-url/-/humanize-url-1.0.1.tgz#f4ab99e0d288174ca4e1e50407c55fbae464efff"
+  integrity sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=
+  dependencies:
+    normalize-url "^1.0.0"
+    strip-url-auth "^1.0.0"
 
 husky@^4.2.5:
   version "4.2.5"
@@ -11057,7 +11104,7 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-url@1.9.1:
+normalize-url@1.9.1, normalize-url@^1.0.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
   integrity sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
@@ -14446,6 +14493,11 @@ strip-outer@^1.0.0:
   integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
   dependencies:
     escape-string-regexp "^1.0.2"
+
+strip-url-auth@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
+  integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
 
 stubs@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Adds support for deploying to github pages via the cli. I looked into automating on merge, but the setup steps are more complicated than the utility of including this feature. I'll add a section to the wiki about how to enable autodeploys in lieu of formal implementation.

To deploy to https://usdigitalresponse.github.io/project-papua/, run `yarn predeploy && yarn deploy`.

This builds and pushes a to a branch called `gh-pages` in this repo. You can run this command from any branch, just make sure to reset the deployed site to master when you're done.

This does not break deployment to Amplify or local testing (via localhost)

I'm open to removing the predeploy step altogether, and instead adding instructions to the readme to explicitly set `PUBLIC_URL` if folks thinks that might make more sense to the unfamiliar.